### PR TITLE
Simplify cookie consent: merge necessary and functional categories

### DIFF
--- a/apps/frontend/components/cookie-consent-banner.tsx
+++ b/apps/frontend/components/cookie-consent-banner.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Cookie } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
-import { cn } from '@/lib/utils'
 import {
   getConsent,
   setConsent,
@@ -15,25 +14,18 @@ import {
 } from '@/lib/cookie-consent'
 
 export function CookieConsentBanner() {
-  const [visible, setVisible] = useState(false)
+  const [visible, setVisible] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return !hasConsent()
+  })
   const [showDetails, setShowDetails] = useState(false)
-  const [consent, setConsentState] = useState<CookieConsent>(DEFAULT_CONSENT)
-
-  useEffect(() => {
-    // Check if user has already consented
-    if (!hasConsent()) {
-      setVisible(true)
-      const stored = getConsent()
-      if (stored) {
-        setConsentState(stored)
-      }
-    }
-  }, [])
+  const [consent, setConsentState] = useState<CookieConsent>(
+    () => getConsent() ?? DEFAULT_CONSENT
+  )
 
   const handleAcceptAll = () => {
     const allAccepted: CookieConsent = {
       necessary: true,
-      functional: true,
       payment: true,
     }
     setConsent(allAccepted)
@@ -48,7 +40,6 @@ export function CookieConsentBanner() {
   const handleRejectNonEssential = () => {
     const minimal: CookieConsent = {
       necessary: true,
-      functional: true, // Can't disable login
       payment: false,
     }
     setConsent(minimal)
@@ -94,28 +85,11 @@ export function CookieConsentBanner() {
                 <div className="flex-1">
                   <div className="font-medium text-sm">Nödvändiga cookies</div>
                   <div className="text-xs text-muted-foreground">
-                    Krävs för att webbplatsen ska fungera korrekt
+                    Krävs för att webbplatsen ska fungera, inklusive inloggning
+                    och sessionshantering
                   </div>
                 </div>
                 <Switch checked={true} disabled />
-              </div>
-
-              {/* Functional cookies */}
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1">
-                  <div className="font-medium text-sm">
-                    Funktionella cookies
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    Möjliggör inloggning och sessionshantering
-                  </div>
-                </div>
-                <Switch
-                  checked={consent.functional}
-                  onCheckedChange={(checked) =>
-                    setConsentState({ ...consent, functional: checked })
-                  }
-                />
               </div>
 
               {/* Payment cookies */}

--- a/apps/frontend/lib/cookie-consent.ts
+++ b/apps/frontend/lib/cookie-consent.ts
@@ -1,6 +1,5 @@
 export interface CookieConsent {
-  necessary: true // Always true, cannot be toggled off
-  functional: boolean // Login session cookies (auth-token)
+  necessary: true // Always true — includes login/session cookies
   payment: boolean // Stripe payment cookies
 }
 
@@ -8,7 +7,6 @@ export const CONSENT_KEY = 'cookie-consent'
 
 export const DEFAULT_CONSENT: CookieConsent = {
   necessary: true,
-  functional: true, // On by default since login requires it
   payment: false, // Off by default
 }
 


### PR DESCRIPTION
## Summary
- Merge "Nödvändiga cookies" and "Funktionella cookies" into a single always-on category
- Login cookies are required for the app to function, so a toggleable "functional" category was misleading
- Now two categories: necessary (includes login/session) and payment (Stripe)
- Fix lint error: replace `useEffect` setState with lazy state initializers

## Test plan
- [ ] Clear localStorage `cookie-consent` key, refresh — banner appears
- [ ] Click "Visa detaljer" — two categories shown (necessary + payment), not three
- [ ] Necessary toggle is always on and disabled
- [ ] Payment toggle works
- [ ] "Acceptera alla" and "Avvisa icke nödvändiga" work correctly